### PR TITLE
FOGL-7812 Missing header files addition in dev package 

### DIFF
--- a/make_deb
+++ b/make_deb
@@ -123,8 +123,10 @@ mkdir -p usr/include/fledge
 cd usr/include/fledge
 # Add Fledge *.h files
 cp -R ${FLEDGE_ROOT}/C/common/include/*.h .
+cp -R ${FLEDGE_ROOT}/C/common/include/exprtk.hpp .
 cp -R ${FLEDGE_ROOT}/C/plugins/common/include/*.h .
 cp -R ${FLEDGE_ROOT}/C/services/common/include/*.h .
+cp -R ${FLEDGE_ROOT}/C/services/south/include/*.h .
 cp -R ${FLEDGE_ROOT}/C/plugins/filter/common/include/*.h .
 echo "  - Fledge header files added."
 # Add third-party include files


### PR DESCRIPTION
C++ Mathematical Expression Toolkit header file and south services header file added into the package.

Here are the custom based [packages](http://archives.dianomic.com/foglamp/fixes/FOGL-7812/ubuntu2004/x86_64/)

